### PR TITLE
FIX cd 아티팩트 다운로드 오류 3

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,7 +27,6 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: my-spring-app-artifact
           path: contents/cicd.demo/build/libs/ # 다운로드할 경로를 지정.
           run-id: ${{ github.event.workflow_run.id }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,11 @@ jobs:
         run: ./gradlew build
         working-directory: contents/cicd.demo
 
-      # 빌드된 JAR 파일을 다음 Job에서 사용할 수 있도록 아티팩트로 저장합니다.
+      # 빌드된 JAR 파일을 다음 Job에서 사용할 수 있도록 아티팩트로 저장
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: my-spring-app-artifact
-          path: contents/cicd.demo/build/libs/ # 빌드된 JAR 파일이 위치한 경로를 명시해야 합니다.
-          # 일반적으로 `build/libs`에 `my-spring-app.jar` 같은 이름으로 생성됩니다.
+          path: contents/cicd.demo/build/libs/ # 빌드된 JAR 파일이 위치한 경로를 명시
 
   dependency-submission:
     runs-on: ubuntu-latest


### PR DESCRIPTION
📝 변경 사항

- 아티팩트 이름이 'artifact'로 자동 설정된다는 문서를 참고. 이름 설정 코드를 삭제
- run id는 냅둠 

🔍 관련 이슈  
이 PR이 해결하는 이슈: #35 

✅ 테스트 결과

- [ ] 기능 테스트 완료
- [ ] 버그 테스트 완료

📌 추가 사항

- <추가로 고려해야 할 사항>
